### PR TITLE
Add option for sampling days, add population ids and rename files

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <div id="controls">
         <div id="pop" class="params">
             <p>Population Parameters</p>
+            <input type="text" id="popId" value="" style="font-family: 'Courier New', Courier, monospace;" disabled/>ID<br />
             <input type="text" id="mutStep" value="64" />Mutation Step<br />
             <input type="text" id="mutRate" value="0.05" />Mutation Rate<br />
             <input type="text" id="popStart" value="100" />Initial Population<br />
@@ -44,6 +45,7 @@
             <p>Data Logging</p>
             <input type="text" id="maxDays" value="10000" />Run length<br />
             <input type="text" id="runName" value="groupselection" />Run name <br />
+            <input type="text" id="sampleDays" value="50" />Sample days <br />
             <input type="checkbox" id="storeAll"/>Save all agents (!)<br />
             <input type="checkbox" id="download"/>Download<br />
         </div><br />


### PR DESCRIPTION
The downloaded files now put the params into their own file to make the importing of csv's easier.
Each population now has a unique ID (random enough for our purposes anyway).
Can now create an additional sample file with every __ days.